### PR TITLE
Add newest release for jquery

### DIFF
--- a/https/repo1.maven.org/maven2/org/webjars/bower/jquery/3.3.1/.directory
+++ b/https/repo1.maven.org/maven2/org/webjars/bower/jquery/3.3.1/.directory
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<title>Central Repository: org/webjars/bower/jquery/3.3.1</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<style>
+body {
+	background: #fff;
+}
+	</style>
+</head>
+
+<body>
+	<header>
+		<h1>org/webjars/bower/jquery/3.3.1</h1>
+	</header>
+	<hr/>
+	<main>
+		<pre id="contents">
+<a href="../">../</a>
+<a href="jquery-3.3.1-javadoc.jar" title="jquery-3.3.1-javadoc.jar">jquery-3.3.1-javadoc.jar</a>                          2018-01-22 09:09        22      
+<a href="jquery-3.3.1-javadoc.jar.asc" title="jquery-3.3.1-javadoc.jar.asc">jquery-3.3.1-javadoc.jar.asc</a>                      2018-01-22 09:09       475      
+<a href="jquery-3.3.1-javadoc.jar.md5" title="jquery-3.3.1-javadoc.jar.md5">jquery-3.3.1-javadoc.jar.md5</a>                      2018-01-22 09:09        32      
+<a href="jquery-3.3.1-javadoc.jar.sha1" title="jquery-3.3.1-javadoc.jar.sha1">jquery-3.3.1-javadoc.jar.sha1</a>                     2018-01-22 09:09        40      
+<a href="jquery-3.3.1-sources.jar" title="jquery-3.3.1-sources.jar">jquery-3.3.1-sources.jar</a>                          2018-01-22 09:09        22      
+<a href="jquery-3.3.1-sources.jar.asc" title="jquery-3.3.1-sources.jar.asc">jquery-3.3.1-sources.jar.asc</a>                      2018-01-22 09:09       475      
+<a href="jquery-3.3.1-sources.jar.md5" title="jquery-3.3.1-sources.jar.md5">jquery-3.3.1-sources.jar.md5</a>                      2018-01-22 09:09        32      
+<a href="jquery-3.3.1-sources.jar.sha1" title="jquery-3.3.1-sources.jar.sha1">jquery-3.3.1-sources.jar.sha1</a>                     2018-01-22 09:09        40      
+<a href="jquery-3.3.1.jar" title="jquery-3.3.1.jar">jquery-3.3.1.jar</a>                                  2018-01-22 09:09    466453      
+<a href="jquery-3.3.1.jar.asc" title="jquery-3.3.1.jar.asc">jquery-3.3.1.jar.asc</a>                              2018-01-22 09:09       475      
+<a href="jquery-3.3.1.jar.md5" title="jquery-3.3.1.jar.md5">jquery-3.3.1.jar.md5</a>                              2018-01-22 09:09        32      
+<a href="jquery-3.3.1.jar.sha1" title="jquery-3.3.1.jar.sha1">jquery-3.3.1.jar.sha1</a>                             2018-01-22 09:09        40      
+<a href="jquery-3.3.1.pom" title="jquery-3.3.1.pom">jquery-3.3.1.pom</a>                                  2018-01-22 09:09      1474      
+<a href="jquery-3.3.1.pom.asc" title="jquery-3.3.1.pom.asc">jquery-3.3.1.pom.asc</a>                              2018-01-22 09:09       475      
+<a href="jquery-3.3.1.pom.md5" title="jquery-3.3.1.pom.md5">jquery-3.3.1.pom.md5</a>                              2018-01-22 09:09        32      
+<a href="jquery-3.3.1.pom.sha1" title="jquery-3.3.1.pom.sha1">jquery-3.3.1.pom.sha1</a>                             2018-01-22 09:09        40      
+		</pre>
+	</main>
+	<hr/>
+</body>
+
+</html>

--- a/https/repo1.maven.org/maven2/org/webjars/bower/jquery/3.3.1/jquery-3.3.1.pom
+++ b/https/repo1.maven.org/maven2/org/webjars/bower/jquery/3.3.1/jquery-3.3.1.pom
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <packaging>jar</packaging>
+    <groupId>org.webjars.bower</groupId>
+    <artifactId>jquery</artifactId>
+    <version>3.3.1</version>
+    <name>jquery</name>
+    <description>WebJar for jquery</description>
+    <url>http://webjars.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <scm>
+        <url>https://github.com/jquery/jquery-dist</url>
+        <connection>https://github.com/jquery/jquery-dist.git</connection>
+        <developerConnection>https://github.com/jquery/jquery-dist.git</developerConnection>
+        <tag>v3.3.1</tag>
+    </scm>
+
+    <developers>
+        <developer>
+            <id>webjars</id>
+            <url>http://webjars.org</url>
+        </developer>
+    </developers>
+
+    <licenses>
+        
+        <license>
+            <name>MIT</name>
+            <url>https://spdx.org/licenses/MIT#licenseText</url>
+            <distribution>repo</distribution>
+        </license>
+        
+    </licenses>
+
+    
+    <issueManagement>
+        <url>https://github.com/jquery/jquery-dist/issues</url>
+    </issueManagement>
+    
+
+    <dependencies>
+        
+        
+    </dependencies>
+
+</project>

--- a/https/repo1.maven.org/maven2/org/webjars/bower/jquery/maven-metadata.xml
+++ b/https/repo1.maven.org/maven2/org/webjars/bower/jquery/maven-metadata.xml
@@ -3,10 +3,13 @@
   <groupId>org.webjars.bower</groupId>
   <artifactId>jquery</artifactId>
   <versioning>
-    <latest>3.2.1</latest>
-    <release>3.2.1</release>
+    <latest>3.3.1</latest>
+    <release>3.3.1</release>
     <versions>
+      <version>1.0.4</version>
+      <version>1.2.2</version>
       <version>1.4.0</version>
+      <version>1.4.4</version>
       <version>1.7.0</version>
       <version>1.7.1</version>
       <version>1.7.2</version>
@@ -16,6 +19,7 @@
       <version>1.8.3</version>
       <version>1.9.0</version>
       <version>1.9.1</version>
+      <version>1.10.0</version>
       <version>1.10.1</version>
       <version>1.10.2</version>
       <version>1.11.0</version>
@@ -46,7 +50,8 @@
       <version>3.1.1</version>
       <version>3.2.0</version>
       <version>3.2.1</version>
+      <version>3.3.1</version>
     </versions>
-    <lastUpdated>20170607212559</lastUpdated>
+    <lastUpdated>20180122092846</lastUpdated>
   </versioning>
 </metadata>


### PR DESCRIPTION
I tried following the instructions from the readme but failed. These files have been manually downloaded with curl.

I ran

```
FILL_CHUNKS=1 sbt "testsJVM/test" -mem 4096
```
but the `test/metadata` folder remained unchanged. What am I doing wrong?

