### PR TITLE
Add org.slf4j:slf4j-simple:1.7.5 POM for test resolution checks

### DIFF
--- a/https/repo1.maven.org/maven2/org/slf4j/slf4j-simple/1.7.5/slf4j-simple-1.7.5.pom
+++ b/https/repo1.maven.org/maven2/org/slf4j/slf4j-simple/1.7.5/slf4j-simple-1.7.5.pom
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <parent>
+    <groupId>org.slf4j</groupId>
+    <artifactId>slf4j-parent</artifactId>
+    <version>1.7.5</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.slf4j</groupId>
+  <artifactId>slf4j-simple</artifactId>
+  <packaging>jar</packaging>
+  <name>SLF4J Simple Binding</name>
+  <description>SLF4J Simple binding</description>
+  <url>http://www.slf4j.org</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+  </dependencies>
+
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Bundle-Version>${parsedVersion.osgiVersion}</Bundle-Version>
+              <Bundle-Description>${project.description}</Bundle-Description>
+              <Implementation-Version>${project.version}</Implementation-Version>
+            </manifestEntries>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
+
+</project>


### PR DESCRIPTION
**Note:** This PR is a dependency for:
- https://github.com/coursier/coursier/pull/3733

This adds the missing mock metadata POM for `org.slf4j:slf4j-simple:1.7.5`.

### Rationale
This metadata is required to pass the `CentralTests.tarGzZipArtifacts` test in `coursier/coursier` after fixing a bug where direct dependencies were incorrectly marked as optional if 
they matched a `<dependencyManagement>` entry specifying `<optional>true</optional>`. 

Because `slf4j-simple` is a direct required dependency of `org.apache.maven:apache-maven:3.3.9`, it is now correctly resolved in the test environment, necessitating this POM file in the mock cache.


